### PR TITLE
Add Markdown/Latex preview terminal

### DIFF
--- a/MyTerm/MyTerm/ContentView.swift
+++ b/MyTerm/MyTerm/ContentView.swift
@@ -1,21 +1,33 @@
-//
-//  ContentView.swift
-//  MyTerm
-//
-//  Created by Juan Angel Serratos on 7/25/25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @State private var input: String = ""
+    @State private var showMarkdown: Bool = true
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        HStack {
+            TerminalWrapper()
+                .frame(minWidth: 400, minHeight: 300)
+            Divider()
+            VStack {
+                TextEditor(text: $input)
+                    .border(Color.secondary)
+                    .frame(minHeight: 150)
+                Picker("Mode", selection: $showMarkdown) {
+                    Text("Markdown").tag(true)
+                    Text("LaTeX").tag(false)
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .padding(.vertical)
+                if showMarkdown {
+                    MarkdownPreview(text: input)
+                } else {
+                    LaTeXPreview(text: input)
+                }
+                Spacer()
+            }
+            .padding()
         }
-        .padding()
     }
 }
 

--- a/MyTerm/MyTerm/LaTeXPreview.swift
+++ b/MyTerm/MyTerm/LaTeXPreview.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import iosMath
+
+#if os(macOS)
+struct LaTeXPreview: NSViewRepresentable {
+    var text: String
+
+    func makeNSView(context: Context) -> MTMathUILabel {
+        let label = MTMathUILabel()
+        label.latex = text
+        label.fontSize = 18
+        label.textAlignment = .left
+        return label
+    }
+
+    func updateNSView(_ nsView: MTMathUILabel, context: Context) {
+        nsView.latex = text
+    }
+}
+#else
+struct LaTeXPreview: UIViewRepresentable {
+    var text: String
+
+    func makeUIView(context: Context) -> MTMathUILabel {
+        let label = MTMathUILabel()
+        label.latex = text
+        label.fontSize = 18
+        label.textAlignment = .left
+        return label
+    }
+
+    func updateUIView(_ uiView: MTMathUILabel, context: Context) {
+        uiView.latex = text
+    }
+}
+#endif

--- a/MyTerm/MyTerm/MarkdownPreview.swift
+++ b/MyTerm/MyTerm/MarkdownPreview.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import MarkdownUI
+
+struct MarkdownPreview: View {
+    var text: String
+    var body: some View {
+        ScrollView {
+            Markdown(text)
+                .padding()
+        }
+    }
+}

--- a/MyTerm/MyTerm/TerminalWrapper.swift
+++ b/MyTerm/MyTerm/TerminalWrapper.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import SwiftTerm
+
+#if os(macOS)
+struct TerminalWrapper: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        let terminal = LocalProcessTerminalView(frame: .zero)
+        terminal.startProcess()
+        return terminal
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+    }
+}
+#else
+struct TerminalWrapper: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let terminal = LocalProcessTerminalView(frame: .zero)
+        terminal.startProcess()
+        return terminal
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+    }
+}
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "MyTerm",
+    platforms: [.macOS(.v14)],
+    products: [
+        .executable(name: "MyTermApp", targets: ["MyTerm"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.2.5"),
+        .package(url: "https://github.com/gonzalezreal/MarkdownUI", from: "1.1.0"),
+        .package(url: "https://github.com/kostub/iosMath", from: "0.9.5")
+    ],
+    targets: [
+        .executableTarget(
+            name: "MyTerm",
+            dependencies: [
+                "SwiftTerm",
+                "MarkdownUI",
+                "iosMath"
+            ],
+            path: "MyTerm/MyTerm",
+            resources: [.process("Assets.xcassets")]
+        ),
+        .testTarget(
+            name: "MyTermTests",
+            dependencies: ["MyTerm"],
+            path: "MyTerm/MyTermTests",
+            sources: ["MyTermTests.swift"]
+        )
+    ]
+)


### PR DESCRIPTION
## Summary
- create Swift Package manifest to build as a native macOS app
- add `TerminalWrapper` that launches a `LocalProcessTerminalView`
- add `MarkdownPreview` using MarkdownUI
- add `LaTeXPreview` using iosMath
- update `ContentView` to show a terminal with a preview panel

## Testing
- `swift build --package-path /workspace/MyTerm` *(fails: the package manifest at '/Package.swift' cannot be accessed)*

------
https://chatgpt.com/codex/tasks/task_e_68841bb79a488322a949a3e613200521