### PR TITLE
Fix iosMath import and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.build/
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,10 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.2.5"),
         .package(url: "https://github.com/gonzalezreal/MarkdownUI", from: "1.1.0"),
-        .package(url: "https://github.com/kostub/iosMath", from: "0.9.5")
+        // Use the master branch of iosMath as the latest tagged release does not
+        // contain a Swift Package manifest. The master branch includes
+        // `Package.swift` enabling Swift Package Manager integration.
+        .package(url: "https://github.com/kostub/iosMath", branch: "master")
     ],
     targets: [
         .executableTarget(

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # MyTerm
+
+MyTerm is a simple SwiftUI terminal application for macOS that can preview Markdown
+and LaTeX alongside a fully functional terminal emulator. It uses
+[SwiftTerm](https://github.com/migueldeicaza/SwiftTerm) for the terminal,
+[MarkdownUI](https://github.com/gonzalezreal/MarkdownUI) for Markdown rendering
+and [iosMath](https://github.com/kostub/iosMath) for LaTeX rendering.
+
+## Building
+
+The project relies on Swift Package Manager. The `iosMath` package does not have
+an official release that includes its `Package.swift` manifest. Therefore the
+`Package.swift` file in this repository points to the `master` branch of
+`iosMath`.
+
+Clone the repository and open the Xcode project (`MyTerm.xcodeproj`) on macOS
+14 or later. Running the project will launch a window containing the terminal,
+a text editor and a preview pane that can toggle between Markdown and LaTeX
+rendering.
+


### PR DESCRIPTION
## Summary
- point iosMath dependency to the master branch because tagged releases lack `Package.swift`
- document build process and dependency notes in README
- add basic `.gitignore`

## Testing
- `swift package resolve --package-path .`

------
https://chatgpt.com/codex/tasks/task_e_68842f59b610832285c4a9f79f4ac60f