### PR TITLE
Refine macOS notes-style app styling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "MyTerm",
+    defaultLocalization: "en",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "MyTermApp", targets: ["MyTermApp"])
+    ],
+    dependencies: [],
+    targets: [
+        .executableTarget(
+            name: "MyTermApp",
+            path: "Sources/MyTermApp",
+            resources: [
+                .process("Resources")
+            ]
+        )
+    ]
+)

--- a/Sources/MyTermApp/Editors/NoteEditorContainer.swift
+++ b/Sources/MyTermApp/Editors/NoteEditorContainer.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct NoteEditorContainer: View {
+    @Binding var note: Note
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        NoteWebEditor(note: $note, colorScheme: colorScheme)
+            .overlay(alignment: .bottomTrailing) {
+                HStack(spacing: 8) {
+                    Image(systemName: "function")
+                    Text("LaTeX enabled")
+                        .font(.caption)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(.thinMaterial, in: Capsule())
+                .padding(12)
+                .opacity(0.85)
+            }
+    }
+}

--- a/Sources/MyTermApp/Editors/NoteWebEditor.swift
+++ b/Sources/MyTermApp/Editors/NoteWebEditor.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+import WebKit
+
+struct NoteWebEditor: NSViewRepresentable {
+    @Binding var note: Note
+    var colorScheme: ColorScheme
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(note: $note)
+    }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.preferences.setValue(true, forKey: "developerExtrasEnabled")
+        configuration.userContentController.add(context.coordinator, name: Coordinator.messageName)
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        webView.isOpaque = false
+        webView.setValue(false, forKey: "drawsBackground")
+        webView.allowsMagnification = false
+
+        if let url = Bundle.module.url(forResource: "editor", withExtension: "html", subdirectory: "Editor") {
+            webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+        }
+
+        context.coordinator.webView = webView
+        context.coordinator.pendingContent = note.content
+        context.coordinator.pendingTitle = note.title
+        context.coordinator.pendingTheme = colorScheme
+
+        return webView
+    }
+
+    func updateNSView(_ nsView: WKWebView, context: Context) {
+        context.coordinator.updateNote(note)
+        context.coordinator.updateThemeIfNeeded(colorScheme)
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        static let messageName = "noteChanged"
+
+        weak var webView: WKWebView?
+        private var isLoaded = false
+        private var lastSyncedContent: String = ""
+        private var lastSyncedTitle: String = ""
+        private var lastTheme: ColorScheme = .light
+
+        var pendingContent: String = ""
+        var pendingTitle: String = ""
+        var pendingTheme: ColorScheme = .light
+
+        private var noteBinding: Binding<Note>
+
+        init(note: Binding<Note>) {
+            self.noteBinding = note
+        }
+
+        func updateNote(_ note: Note) {
+            guard isLoaded else {
+                pendingContent = note.content
+                pendingTitle = note.title
+                return
+            }
+
+            if note.content != lastSyncedContent {
+                setContent(note.content)
+            }
+
+            if note.title != lastSyncedTitle {
+                setTitle(note.title)
+            }
+        }
+
+        func updateThemeIfNeeded(_ theme: ColorScheme) {
+            guard isLoaded else {
+                pendingTheme = theme
+                return
+            }
+
+            if theme != lastTheme {
+                applyTheme(theme)
+            }
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            isLoaded = true
+            setContent(pendingContent)
+            setTitle(pendingTitle)
+            applyTheme(pendingTheme)
+        }
+
+        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            guard message.name == Coordinator.messageName else { return }
+            if let body = message.body as? [String: Any] {
+                handleMessage(body)
+            } else if let text = message.body as? String {
+                handleTextMessage(text)
+            }
+        }
+
+        private func handleMessage(_ payload: [String: Any]) {
+            if let content = payload["content"] as? String {
+                handleTextMessage(content)
+            }
+            if let title = payload["title"] as? String {
+                Task { @MainActor in
+                    var current = noteBinding.wrappedValue
+                    current.title = title
+                    noteBinding.wrappedValue = current
+                    lastSyncedTitle = title
+                }
+            }
+        }
+
+        private func handleTextMessage(_ text: String) {
+            Task { @MainActor in
+                var current = noteBinding.wrappedValue
+                current.content = text
+                current.updatedAt = .now
+                current.title = Note.title(from: text, fallback: current.title)
+                noteBinding.wrappedValue = current
+                lastSyncedContent = text
+                lastSyncedTitle = current.title
+            }
+        }
+
+        private func setContent(_ text: String) {
+            lastSyncedContent = text
+            let escaped = text.escapedForJavaScript()
+            let script = "window.noteBridge.setContent(\"\(escaped)\");"
+            webView?.evaluateJavaScript(script) { _, error in
+                #if DEBUG
+                if let error {
+                    print("JavaScript content error: \(error.localizedDescription)")
+                }
+                #endif
+            }
+        }
+
+        private func setTitle(_ title: String) {
+            lastSyncedTitle = title
+            let escaped = title.escapedForJavaScript()
+            let script = "window.noteBridge.setTitle(\"\(escaped)\");"
+            webView?.evaluateJavaScript(script, completionHandler: nil)
+        }
+
+        private func applyTheme(_ theme: ColorScheme) {
+            lastTheme = theme
+            let mode = theme == .dark ? "dark" : "light"
+            let script = "window.noteBridge.setAppearance(\"\(mode)\");"
+            webView?.evaluateJavaScript(script, completionHandler: nil)
+        }
+    }
+}
+
+private extension String {
+    func escapedForJavaScript() -> String {
+        var result = self
+        result = result
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+        return result
+    }
+}

--- a/Sources/MyTermApp/Models/Note.swift
+++ b/Sources/MyTermApp/Models/Note.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct Note: Identifiable, Equatable {
+    let id: UUID
+    var title: String
+    var content: String
+    var updatedAt: Date
+
+    init(id: UUID = UUID(), title: String, content: String, updatedAt: Date = .now) {
+        self.id = id
+        self.title = title
+        self.content = content
+        self.updatedAt = updatedAt
+    }
+
+    var previewLine: String {
+        let trimmed = content
+            .split(whereSeparator: { $0.isNewline })
+            .first
+            .map(String.init)
+            ?? ""
+        return trimmed.isEmpty ? "New note" : trimmed
+    }
+
+    static func title(from content: String, fallback: String) -> String {
+        let firstLine = content
+            .split(whereSeparator: { $0.isNewline })
+            .first
+            .map(String.init)
+            ?? ""
+        let trimmed = firstLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? fallback : trimmed
+    }
+}

--- a/Sources/MyTermApp/Models/NotesStore.swift
+++ b/Sources/MyTermApp/Models/NotesStore.swift
@@ -1,0 +1,70 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class NotesStore: ObservableObject {
+    @Published var notes: [Note]
+    @Published var selectedNoteID: UUID?
+    @Published var searchText: String = ""
+
+    init() {
+        let sampleContent = """
+Meeting Notes
+
+Planning the next release with inline math $f(x) = x^2 + 1$ and a displayed block:
+
+$$\\begin{align*}
+F(n) &= F(n-1) + F(n-2)\\\\
+\\Phi &= \\frac{1 + \\sqrt{5}}{2}
+\\end{align*}$$
+
+We can also declare operators using \\DeclareMathOperator{\\Sym}{Sym}.
+"""
+
+        let first = Note(title: "Team Sync", content: sampleContent)
+        let second = Note(
+            title: "Research",
+            content: """
+Remember to define \\newcommand{\\RR}{\\mathbb{R}} before using it.
+
+Then $\\RR$ renders automatically and matrices like $\\begin{pmatrix}1 & 2\\\\3 & 4\\end{pmatrix}$ look great.
+"""
+        )
+        notes = [first, second]
+        selectedNoteID = notes.first?.id
+    }
+
+    func binding(for id: UUID?) -> Binding<Note>? {
+        guard let id, let index = notes.firstIndex(where: { $0.id == id }) else {
+            return nil
+        }
+
+        return Binding(
+            get: { self.notes[index] },
+            set: { newValue in
+                self.notes[index] = newValue
+            }
+        )
+    }
+
+    func createNote() {
+        let newNote = Note(title: "New Note", content: "")
+        notes.insert(newNote, at: 0)
+        selectedNoteID = newNote.id
+    }
+
+    func deleteNotes(at offsets: IndexSet) {
+        notes.remove(atOffsets: offsets)
+        if let currentID = selectedNoteID, !notes.contains(where: { $0.id == currentID }) {
+            selectedNoteID = notes.first?.id
+        }
+    }
+    func deleteNotes(withIDs ids: [UUID]) {
+        guard !ids.isEmpty else { return }
+        notes.removeAll { ids.contains($0.id) }
+        if let currentID = selectedNoteID, !notes.contains(where: { $0.id == currentID }) {
+            selectedNoteID = notes.first?.id
+        }
+    }
+
+}

--- a/Sources/MyTermApp/MyTermApp.swift
+++ b/Sources/MyTermApp/MyTermApp.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+@main
+struct MyTermApp: App {
+    @StateObject private var store = NotesStore()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(store)
+                .frame(minWidth: 900, minHeight: 600)
+        }
+        .windowStyle(.hiddenTitleBar)
+    }
+}

--- a/Sources/MyTermApp/Resources/Editor/editor.css
+++ b/Sources/MyTermApp/Resources/Editor/editor.css
@@ -1,0 +1,104 @@
+:root {
+    color-scheme: light dark;
+    --editor-background-light: #f8fafc;
+    --editor-background-dark: #05060a;
+    --editor-foreground-light: #0f172a;
+    --editor-foreground-dark: #f8fafc;
+    --editor-selection-light: rgba(15, 23, 42, 0.15);
+    --editor-selection-dark: rgba(148, 163, 184, 0.25);
+    --editor-font-family: "SF Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    font-family: var(--editor-font-family);
+    background: transparent;
+    color: var(--editor-foreground-light);
+}
+
+body.dark {
+    color: var(--editor-foreground-dark);
+}
+
+#editor-shell {
+    position: relative;
+    width: 100%;
+    height: 100vh;
+    background: linear-gradient(135deg, rgba(15, 17, 23, 0.08), rgba(9, 9, 11, 0.14));
+    border-radius: 22px;
+    overflow: hidden;
+}
+
+#note-editor {
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    padding: 32px 40px 80px 40px;
+    font-size: 16px;
+    line-height: 1.6;
+    color: inherit;
+    background-color: rgba(255, 255, 255, 0.82);
+    border: none;
+    outline: none;
+    overflow-y: auto;
+    -webkit-user-select: text;
+}
+
+body.dark #note-editor {
+    background-color: rgba(15, 17, 23, 0.78);
+}
+
+#note-editor:focus {
+    box-shadow: inset 0 0 0 2px rgba(94, 234, 212, 0.35);
+    border-radius: 18px;
+}
+
+#note-editor div {
+    min-height: 1.2em;
+}
+
+#note-editor .math-fragment {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 4px;
+    border-radius: 8px;
+    background: rgba(94, 234, 212, 0.12);
+    margin: 0 2px;
+    cursor: pointer;
+}
+
+#note-editor .math-fragment.math-display {
+    display: block;
+    padding: 12px 16px;
+    margin: 12px 0;
+    text-align: center;
+}
+
+#note-editor .math-fragment:hover {
+    background: rgba(94, 234, 212, 0.22);
+}
+
+#note-editor .math-error {
+    background: rgba(239, 68, 68, 0.18);
+    color: #ef4444;
+}
+
+#note-editor ::selection {
+    background: var(--editor-selection-light);
+}
+
+body.dark #note-editor ::selection {
+    background: var(--editor-selection-dark);
+}
+
+.katex-display {
+    margin: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        color: var(--editor-foreground-dark);
+    }
+}

--- a/Sources/MyTermApp/Resources/Editor/editor.html
+++ b/Sources/MyTermApp/Resources/Editor/editor.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MyTerm Note Editor</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-TZbYr7YwHxZ34rnOG0r8QwMCKaRZ3eLaxhUJW6QcgO5Kb/6VQwWi4KFOeFH0bZJG" crossorigin="anonymous">
+    <link rel="stylesheet" href="editor.css" />
+</head>
+<body>
+    <div id="editor-shell">
+        <div id="note-editor" contenteditable="true" spellcheck="false"></div>
+    </div>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" integrity="sha384-OZ59fzOEx+kt1/3uzMdGII4XESyqSeX5TR1+t0NenE2no0RvrRZtGJPD7W82dMan" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js" integrity="sha384-mll67QQIcbMglgNXh9vDOMkMt2rt7NmBGG99nmHn7+PBkO5OVwOB1p5YBkPCE4e4" crossorigin="anonymous"></script>
+    <script defer src="editor.js"></script>
+</body>
+</html>

--- a/Sources/MyTermApp/Resources/Editor/editor.js
+++ b/Sources/MyTermApp/Resources/Editor/editor.js
@@ -1,0 +1,573 @@
+(() => {
+    const editor = document.getElementById('note-editor');
+    if (!editor) {
+        return;
+    }
+
+    let currentRawText = '';
+    let macros = {};
+    let environments = {};
+    let suppressNotification = false;
+
+    const defaultMacros = {
+        '\\RR': '\\mathbb{R}',
+        '\\QQ': '\\mathbb{Q}',
+        '\\ZZ': '\\mathbb{Z}',
+        '\\NN': '\\mathbb{N}',
+        '\\CC': '\\mathbb{C}',
+        '\\EE': '\\mathbb{E}',
+        '\\Var': '\\operatorname{Var}',
+        '\\Cov': '\\operatorname{Cov}',
+        '\\grad': '\\nabla'
+    };
+
+    const defaultEnvironments = {
+        lemma: { title: 'Lemma' },
+        theorem: { title: 'Theorem' },
+        proposition: { title: 'Proposition' },
+        corollary: { title: 'Corollary' },
+        definition: { title: 'Definition' }
+    };
+
+    const delimiters = [
+        { left: '$$', right: '$$', display: true },
+        { left: '\\[', right: '\\]', display: true },
+        { left: '\\(', right: '\\)', display: false },
+        { left: '$', right: '$', display: false }
+    ];
+
+    function initialize() {
+        editor.addEventListener('input', handleInput);
+        editor.addEventListener('paste', handlePaste);
+        editor.addEventListener('drop', event => event.preventDefault());
+        editor.addEventListener('keydown', event => {
+            if (event.key === 'Tab') {
+                event.preventDefault();
+                insertText('    ');
+            }
+        });
+        editor.addEventListener('dblclick', handleDoubleClick);
+
+        ensureBaseLine();
+        renderContent({ preserveSelection: false });
+    }
+
+    function ensureBaseLine() {
+        if (editor.childNodes.length === 0) {
+            const div = document.createElement('div');
+            div.appendChild(document.createElement('br'));
+            editor.appendChild(div);
+        }
+    }
+
+    function handleInput() {
+        renderContent();
+    }
+
+    function handlePaste(event) {
+        event.preventDefault();
+        const text = (event.clipboardData || window.clipboardData).getData('text/plain');
+        insertText(text);
+    }
+
+    function handleDoubleClick(event) {
+        const target = event.target.closest('.math-fragment');
+        if (!target) {
+            return;
+        }
+        const latex = target.dataset.latex || '';
+        const textNode = document.createTextNode(latex);
+        target.replaceWith(textNode);
+        placeCaretAfter(textNode, latex.length);
+        renderContent();
+    }
+
+    function insertText(text) {
+        const selection = window.getSelection();
+        if (!selection || selection.rangeCount === 0) {
+            return;
+        }
+        const range = selection.getRangeAt(0);
+        range.deleteContents();
+        range.insertNode(document.createTextNode(text));
+        range.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        renderContent();
+    }
+
+    function handleThemeChange(mode) {
+        document.body.classList.toggle('dark', mode === 'dark');
+    }
+
+    function handleInputFromHost(text) {
+        suppressNotification = true;
+        populateEditor(text);
+        renderContent({ preserveSelection: false });
+        currentRawText = text;
+        suppressNotification = false;
+    }
+
+    function populateEditor(text) {
+        editor.innerHTML = '';
+        const lines = text.split(/\r?\n/);
+        lines.forEach((line, index) => {
+            const div = document.createElement('div');
+            if (line.length === 0) {
+                div.appendChild(document.createElement('br'));
+            } else {
+                div.appendChild(document.createTextNode(line));
+            }
+            editor.appendChild(div);
+            if (index === lines.length - 1 && line.length === 0) {
+                div.appendChild(document.createElement('br'));
+            }
+        });
+        ensureBaseLine();
+    }
+
+    function renderContent({ preserveSelection = true } = {}) {
+        const selectionSnapshot = preserveSelection ? captureSelection() : null;
+        revertMathFragments(editor);
+        const rawText = extractRawText(editor);
+        updateDefinitions(rawText);
+        typesetMathInEditor();
+        if (selectionSnapshot) {
+            restoreSelection(selectionSnapshot);
+        }
+        notifyHostIfNeeded(rawText);
+    }
+
+    function captureSelection() {
+        const selection = window.getSelection();
+        if (!selection || selection.rangeCount === 0) {
+            return null;
+        }
+        const range = selection.getRangeAt(0);
+        const cloneStart = range.cloneRange();
+        cloneStart.selectNodeContents(editor);
+        cloneStart.setEnd(range.startContainer, range.startOffset);
+        const startFragment = cloneStart.cloneContents();
+        const startOffset = computeRawLength(startFragment);
+
+        let endOffset = startOffset;
+        if (!selection.isCollapsed) {
+            const cloneEnd = range.cloneRange();
+            cloneEnd.selectNodeContents(editor);
+            cloneEnd.setEnd(range.endContainer, range.endOffset);
+            const endFragment = cloneEnd.cloneContents();
+            endOffset = computeRawLength(endFragment);
+        }
+
+        return { start: startOffset, end: endOffset };
+    }
+
+    function restoreSelection(snapshot) {
+        if (!snapshot) {
+            return;
+        }
+        const segments = collectSegments(editor);
+        const startPosition = locatePosition(segments, snapshot.start);
+        const endPosition = locatePosition(segments, snapshot.end);
+        if (!startPosition || !endPosition) {
+            placeCaretAtEnd();
+            return;
+        }
+        const range = document.createRange();
+        range.setStart(startPosition.node, startPosition.offset);
+        range.setEnd(endPosition.node, endPosition.offset);
+        const selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(range);
+    }
+
+    function placeCaretAfter(node, offset) {
+        const range = document.createRange();
+        range.setStart(node, offset);
+        range.setEnd(node, offset);
+        const selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(range);
+    }
+
+    function placeCaretAtEnd() {
+        const range = document.createRange();
+        range.selectNodeContents(editor);
+        range.collapse(false);
+        const selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(range);
+    }
+
+    function revertMathFragments(root) {
+        const fragments = root.querySelectorAll('.math-fragment');
+        fragments.forEach(fragment => {
+            const latex = fragment.dataset.latex || '';
+            const textNode = document.createTextNode(latex);
+            fragment.replaceWith(textNode);
+        });
+    }
+
+    function typesetMathInEditor() {
+        if (!window.katex) {
+            return;
+        }
+        const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT, null);
+        const nodes = [];
+        let current;
+        while ((current = walker.nextNode())) {
+            if (!current.textContent || current.textContent.trim().length === 0) {
+                continue;
+            }
+            if (current.parentElement && current.parentElement.classList.contains('math-fragment')) {
+                continue;
+            }
+            nodes.push(current);
+        }
+
+        nodes.forEach(node => {
+            const fragment = transformTextNode(node);
+            if (fragment) {
+                node.replaceWith(fragment);
+            }
+        });
+    }
+
+    function transformTextNode(node) {
+        const text = node.textContent || '';
+        const segments = extractSegments(text);
+        if (!segments.some(segment => segment.type === 'math')) {
+            return null;
+        }
+        const fragment = document.createDocumentFragment();
+        segments.forEach(segment => {
+            if (segment.type === 'text') {
+                fragment.appendChild(document.createTextNode(segment.value));
+                return;
+            }
+
+            const mathContainer = document.createElement(segment.display ? 'div' : 'span');
+            mathContainer.classList.add('math-fragment');
+            mathContainer.dataset.latex = segment.raw;
+            if (segment.display) {
+                mathContainer.classList.add('math-display');
+            } else {
+                mathContainer.classList.add('math-inline');
+            }
+
+            const latex = applyEnvironmentTransforms(segment.content);
+            try {
+                window.katex.render(latex, mathContainer, {
+                    displayMode: segment.display,
+                    throwOnError: false,
+                    macros
+                });
+            } catch (error) {
+                mathContainer.classList.add('math-error');
+                mathContainer.textContent = segment.raw;
+            }
+            fragment.appendChild(mathContainer);
+        });
+        return fragment;
+    }
+
+    function extractSegments(text) {
+        const segments = [];
+        let index = 0;
+        while (index < text.length) {
+            const match = findNextDelimiter(text, index);
+            if (!match) {
+                segments.push({ type: 'text', value: text.slice(index) });
+                break;
+            }
+
+            if (match.index > index) {
+                segments.push({ type: 'text', value: text.slice(index, match.index) });
+            }
+
+            const start = match.index + match.delimiter.left.length;
+            const end = findClosing(text, start, match.delimiter.right);
+            if (end === -1) {
+                segments.push({ type: 'text', value: text.slice(match.index) });
+                break;
+            }
+
+            const raw = text.slice(match.index, end + match.delimiter.right.length);
+            const content = text.slice(start, end);
+            segments.push({
+                type: 'math',
+                content,
+                raw,
+                display: match.delimiter.display
+            });
+            index = end + match.delimiter.right.length;
+        }
+        return segments;
+    }
+
+    function findNextDelimiter(text, startIndex) {
+        let closest = null;
+        delimiters.forEach(delimiter => {
+            let position = text.indexOf(delimiter.left, startIndex);
+            while (position !== -1 && isEscaped(text, position)) {
+                position = text.indexOf(delimiter.left, position + delimiter.left.length);
+            }
+            if (position !== -1 && (closest === null || position < closest.index)) {
+                closest = { index: position, delimiter };
+            }
+        });
+        return closest;
+    }
+
+    function findClosing(text, startIndex, closing) {
+        let position = startIndex;
+        while (position < text.length) {
+            const candidate = text.indexOf(closing, position);
+            if (candidate === -1) {
+                return -1;
+            }
+            if (!isEscaped(text, candidate)) {
+                return candidate;
+            }
+            position = candidate + closing.length;
+        }
+        return -1;
+    }
+
+    function isEscaped(text, index) {
+        let slashCount = 0;
+        let i = index - 1;
+        while (i >= 0 && text[i] === '\\') {
+            slashCount += 1;
+            i -= 1;
+        }
+        return slashCount % 2 === 1;
+    }
+
+    function updateDefinitions(rawText) {
+        macros = { ...defaultMacros };
+        environments = { ...defaultEnvironments };
+
+        const macroRegex = /\\newcommand\s*\{\\([a-zA-Z@]+)\}(?:\[(\d+)\])?\s*\{([\s\S]*?)\}/g;
+        rawText.replace(macroRegex, (_, name, _argCount, definition) => {
+            macros[`\\${name}`] = definition;
+            return '';
+        });
+
+        const declareRegex = /\\DeclareMathOperator\s*\{\\([a-zA-Z@]+)\}\s*\{([\s\S]*?)\}/g;
+        rawText.replace(declareRegex, (_, name, body) => {
+            macros[`\\${name}`] = `\\operatorname{${body}}`;
+            return '';
+        });
+
+        const environmentRegex = /\\newenvironment\s*\{([a-zA-Z*@]+)\}(?:\[(\d+)\])?\s*\{([\s\S]*?)\}\s*\{([\s\S]*?)\}/g;
+        rawText.replace(environmentRegex, (_, name, argCount, begin, end) => {
+            environments[name] = {
+                begin,
+                end,
+                argCount: argCount ? parseInt(argCount, 10) : 0
+            };
+            return '';
+        });
+    }
+
+    function applyEnvironmentTransforms(latex) {
+        const pattern = /\\begin\{([a-zA-Z*@]+)\}([\s\S]*?)\\end\{\1\}/g;
+        return latex.replace(pattern, (_, name, body) => renderEnvironment(name, body));
+    }
+
+    function renderEnvironment(name, body) {
+        const definition = environments[name];
+        if (!definition) {
+            return `\\begin{${name}}${body}\\end{${name}}`;
+        }
+
+        if (definition.title) {
+            const label = definition.title;
+            const inner = applyEnvironmentTransforms(body.trim());
+            return `\\boxed{\\textbf{${label}.}\\quad ${inner}}`;
+        }
+
+        let remainder = body;
+        const args = [];
+        if (definition.argCount && definition.argCount > 0) {
+            for (let i = 0; i < definition.argCount; i += 1) {
+                remainder = remainder.trimStart();
+                if (!remainder.startsWith('{')) {
+                    break;
+                }
+                const extracted = extractBalanced(remainder);
+                if (!extracted) {
+                    break;
+                }
+                args.push(extracted.content);
+                remainder = remainder.slice(extracted.length);
+            }
+        }
+
+        let begin = definition.begin;
+        let end = definition.end;
+        args.forEach((arg, index) => {
+            const token = new RegExp(`#${index + 1}`, 'g');
+            begin = begin.replace(token, arg);
+            end = end.replace(token, arg);
+        });
+
+        const inner = applyEnvironmentTransforms(remainder);
+        return `${begin}${inner}${end}`;
+    }
+
+    function extractBalanced(text) {
+        if (!text.startsWith('{')) {
+            return null;
+        }
+        let depth = 0;
+        for (let i = 0; i < text.length; i += 1) {
+            const char = text[i];
+            if (char === '{') {
+                depth += 1;
+            } else if (char === '}') {
+                depth -= 1;
+                if (depth === 0) {
+                    return {
+                        content: text.slice(1, i),
+                        length: i + 1
+                    };
+                }
+            }
+        }
+        return null;
+    }
+
+    function extractRawText(root) {
+        const segments = collectSegments(root);
+        return segments.map(segment => segment.value).join('');
+    }
+
+    function collectSegments(root) {
+        const segments = [];
+        const children = Array.from(root.childNodes);
+        children.forEach((child, index) => {
+            appendSegments(child, segments);
+            if (child.nodeName === 'DIV' && index < children.length - 1) {
+                segments.push({ type: 'newline', node: child, value: '\n', length: 1 });
+            }
+        });
+        if (segments.length === 0) {
+            segments.push({ type: 'text', node: root, value: '', length: 0 });
+        }
+        return segments;
+    }
+
+    function appendSegments(node, segments) {
+        if (node.nodeType === Node.TEXT_NODE) {
+            if (node.textContent && node.textContent.length > 0) {
+                segments.push({ type: 'text', node, value: node.textContent, length: node.textContent.length });
+            }
+            return;
+        }
+        if (node.nodeType !== Node.ELEMENT_NODE) {
+            return;
+        }
+        if (node.classList.contains('math-fragment')) {
+            const latex = node.dataset.latex || '';
+            segments.push({ type: 'math', node, value: latex, length: latex.length });
+            return;
+        }
+        if (node.nodeName === 'BR') {
+            segments.push({ type: 'newline', node, value: '\n', length: 1 });
+            return;
+        }
+        const children = Array.from(node.childNodes);
+        children.forEach(child => appendSegments(child, segments));
+    }
+
+    function locatePosition(segments, offset) {
+        let remaining = offset;
+        for (const segment of segments) {
+            const length = segment.length ?? segment.value.length;
+            if (remaining > length) {
+                remaining -= length;
+                continue;
+            }
+            if (segment.type === 'text') {
+                return { node: segment.node, offset: remaining };
+            }
+            if (segment.type === 'math') {
+                const parent = segment.node.parentNode || editor;
+                const index = Array.prototype.indexOf.call(parent.childNodes, segment.node);
+                return { node: parent, offset: remaining === 0 ? index : index + 1 };
+            }
+            if (segment.type === 'newline') {
+                const parent = segment.node.parentNode || editor;
+                const index = Array.prototype.indexOf.call(parent.childNodes, segment.node);
+                return { node: parent, offset: index + 1 };
+            }
+        }
+        const parent = editor;
+        return { node: parent, offset: parent.childNodes.length };
+    }
+
+    function computeRawLength(fragment) {
+        let total = 0;
+        fragment.childNodes.forEach(child => {
+            total += nodeRawLength(child);
+        });
+        return total;
+    }
+
+    function nodeRawLength(node) {
+        if (node.nodeType === Node.TEXT_NODE) {
+            return node.textContent.length;
+        }
+        if (node.nodeType !== Node.ELEMENT_NODE) {
+            return 0;
+        }
+        if (node.classList.contains('math-fragment')) {
+            const latex = node.dataset.latex || '';
+            return latex.length;
+        }
+        if (node.nodeName === 'BR') {
+            return 1;
+        }
+        let total = 0;
+        node.childNodes.forEach(child => {
+            total += nodeRawLength(child);
+        });
+        if (node.nodeName === 'DIV') {
+            total += 1;
+        }
+        return total;
+    }
+
+    function notifyHostIfNeeded(text) {
+        if (suppressNotification || text === currentRawText) {
+            return;
+        }
+        currentRawText = text;
+        if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.noteChanged) {
+            window.webkit.messageHandlers.noteChanged.postMessage({ content: text });
+        }
+    }
+
+    window.noteBridge = {
+        setContent(text) {
+            handleInputFromHost(text || '');
+        },
+        setAppearance(mode) {
+            handleThemeChange(mode);
+        },
+        setTitle() {
+            // Reserved for future enhancements.
+        },
+        focus() {
+            editor.focus();
+        }
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initialize, { once: true });
+    } else {
+        initialize();
+    }
+})();

--- a/Sources/MyTermApp/Supporting/Color+Hex.swift
+++ b/Sources/MyTermApp/Supporting/Color+Hex.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+extension Color {
+    init(hex: UInt32, alpha: Double = 1.0) {
+        let red = Double((hex & 0xFF0000) >> 16) / 255.0
+        let green = Double((hex & 0x00FF00) >> 8) / 255.0
+        let blue = Double(hex & 0x0000FF) / 255.0
+        self.init(.sRGB, red: red, green: green, blue: blue, opacity: alpha)
+    }
+}

--- a/Sources/MyTermApp/Views/ContentView.swift
+++ b/Sources/MyTermApp/Views/ContentView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var store: NotesStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var filteredNotes: [Note] {
+        guard !store.searchText.isEmpty else { return store.notes }
+        let query = store.searchText.lowercased()
+        return store.notes.filter { note in
+            note.title.lowercased().contains(query) || note.content.lowercased().contains(query)
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            SidebarView(notes: filteredNotes)
+                .frame(width: 260)
+                .background(sidebarBackground)
+
+            Divider()
+                .foregroundStyle(.quaternary)
+
+            if let binding = store.binding(for: store.selectedNoteID) {
+                NoteDetailView(note: binding)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(mainBackground)
+            } else {
+                PlaceholderView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(mainBackground)
+            }
+        }
+        .frame(minWidth: 960, minHeight: 600)
+        .background(windowBackground)
+    }
+
+    private var sidebarBackground: some View {
+        Color(nsColor: colorScheme == .dark ? .controlBackgroundColor : .windowBackgroundColor)
+    }
+
+    private var mainBackground: some View {
+        Color(nsColor: colorScheme == .dark ? .textBackgroundColor : .underPageBackgroundColor)
+    }
+
+    private var windowBackground: some View {
+        Color(nsColor: .windowBackgroundColor)
+            .ignoresSafeArea()
+    }
+}
+
+private struct PlaceholderView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "square.and.pencil")
+                .font(.system(size: 40, weight: .ultraLight))
+                .foregroundStyle(.tertiary)
+            Text("Select a note to view or create a new one")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(NotesStore())
+        .frame(width: 1024, height: 768)
+}

--- a/Sources/MyTermApp/Views/NoteDetailView.swift
+++ b/Sources/MyTermApp/Views/NoteDetailView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct NoteDetailView: View {
+    @Binding var note: Note
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+                .foregroundStyle(.quaternary)
+            editor
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            TextField("Title", text: $note.title)
+                .textFieldStyle(.plain)
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundColor(.primary)
+                .onChange(of: note.title) { _ in
+                    note.updatedAt = .now
+                }
+
+            Text(note.updatedAt, format: .dateTime.month().day().year().hour().minute())
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 32)
+        .padding(.top, 24)
+        .padding(.bottom, 16)
+    }
+
+    private var editor: some View {
+        NoteEditorContainer(note: $note)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 20)
+    }
+}

--- a/Sources/MyTermApp/Views/SidebarView.swift
+++ b/Sources/MyTermApp/Views/SidebarView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+struct SidebarView: View {
+    @EnvironmentObject private var store: NotesStore
+    @State private var hoveredNoteID: UUID?
+
+    let notes: [Note]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            searchField
+            Divider()
+                .foregroundStyle(.quaternary)
+            notesList
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Notes")
+                    .font(.system(size: 22, weight: .semibold))
+                Text("All iCloud")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button(action: store.createNote) {
+                Image(systemName: "square.and.pencil")
+                    .symbolVariant(.fill)
+                    .font(.system(size: 15, weight: .medium))
+                    .padding(6)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityLabel("Create a new note")
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 20)
+        .padding(.bottom, 12)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Search", text: $store.searchText)
+                .textFieldStyle(.plain)
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color(nsColor: .quaternaryLabelColor))
+        )
+        .padding(.horizontal, 16)
+        .padding(.bottom, 12)
+    }
+
+    private var notesList: some View {
+        List(selection: $store.selectedNoteID) {
+            ForEach(notes) { note in
+                NoteRow(note: note, isHovered: hoveredNoteID == note.id)
+                    .listRowBackground(Color.clear)
+                    .tag(note.id)
+                    .onHover { hovering in
+                        hoveredNoteID = hovering ? note.id : nil
+                    }
+            }
+            .onDelete(perform: deleteNotes)
+        }
+        .listStyle(.sidebar)
+        .scrollContentBackground(.hidden)
+    }
+
+    private func deleteNotes(at offsets: IndexSet) {
+        let ids = offsets.compactMap { index -> UUID? in
+            guard notes.indices.contains(index) else { return nil }
+            return notes[index].id
+        }
+        store.deleteNotes(withIDs: ids)
+    }
+}
+
+private struct NoteRow: View {
+    let note: Note
+    let isHovered: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(note.title)
+                .font(.headline)
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+            Text(note.previewLine)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 4)
+        .contentShape(Rectangle())
+    }
+}


### PR DESCRIPTION
## Summary
- refine the SwiftUI notes layout and styling to more closely mirror the native macOS Notes appearance
- embed a WKWebView-driven editor that syncs Swift state with an HTML/KaTeX renderer capable of macros, math operators, and theorem-style environments
- include local resources for the editor UI along with KaTeX configuration and styling tuned to a Vercel-inspired aesthetic

## Testing
- `swift build` *(fails in the container because SwiftUI is unavailable on Linux)*

------
https://chatgpt.com/codex/tasks/task_b_68e007eccf408324a802d250321c6cb8