### PR TITLE
Add macOS SwiftUI notes app with inline LaTeX rendering

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "MyTermNotes",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(
+            name: "MyTermNotes",
+            targets: ["MyTermNotesApp"]
+        )
+    ],
+    dependencies: [],
+    targets: [
+        .executableTarget(
+            name: "MyTermNotesApp",
+            resources: [
+                .process("../Resources/Renderer")
+            ],
+            swiftSettings: [
+                .define("SWIFTUI_APP")
+            ],
+            linkerSettings: [
+                .linkedFramework("AppKit"),
+                .linkedFramework("SwiftUI"),
+                .linkedFramework("WebKit")
+            ]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# MyTerm Notes
+
+A SwiftUI-based macOS note-taking experience inspired by Apple Notes with a Vercel aesthetic and native-quality LaTeX rendering. Mathematical expressions typed with `$ ... $`, `$$ ... $$`, `\( ... \)`, `\[ ... \]`, or LaTeX environments render inline while keeping the editing experience smooth.
+
+## Highlights
+
+- **Elegant interface** that echoes macOS Notes while leaning into Vercel-inspired neutrals, translucency, and rounded geometry.
+- **Realtime LaTeX** rendering powered by an off-screen WebKit renderer and KaTeX. Inline and display math, matrices, alignment environments, and theorem-style blocks render directly in the editor.
+- **Custom macro support** for `\newcommand`, `\DeclareMathOperator`, and `\newenvironment` definitions via the app's Settings pane.
+- **Persistent storage** using Application Support so notes and LaTeX preferences are restored between launches.
+- **Keyboard-friendly workflow** with Command+N to create notes and familiar macOS split-view navigation.
+
+## Getting Started
+
+1. Open the project in Xcode 15 or newer (macOS 13 target).
+2. Build & run the executable target `MyTermNotes` on macOS.
+3. Use the Settings pane (`⌘,`) to paste your favorite LaTeX macros and environment definitions.
+
+## Project Structure
+
+- `Package.swift` — Swift Package Manager manifest configured for a SwiftUI App target.
+- `Sources/MyTermNotesApp` — Application sources (app state, views, LaTeX renderer, theme).
+- `Resources/Renderer` — HTML harness used by the off-screen WebKit renderer to produce KaTeX snapshots.
+
+## Requirements
+
+- macOS 13+
+- Xcode 15+
+
+KaTeX assets are served from jsDelivr CDN. An active internet connection is required for the first render to download KaTeX once per session.

--- a/Resources/Renderer/renderer.html
+++ b/Resources/Renderer/renderer.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-VZFGxUY8ailqXFz3vGN9VOGBev5nYeD1yfknhk+aoCA8DmFumiQJ5AZt0ArO7E2W" crossorigin="anonymous">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" integrity="sha384-+04UD58Ll35H5TADaBrZEcD3xKhsR4HIX66vepQP9en5ZaY1fZLrSSAG2wE8xmPK" crossorigin="anonymous"></script>
+    <style>
+        :root {
+            color-scheme: light dark;
+        }
+        body {
+            margin: 0;
+            font-family: "SF Pro", "Inter", system-ui, -apple-system, BlinkMacSystemFont;
+            background: transparent;
+        }
+        #container {
+            padding: 12px;
+            display: inline-block;
+        }
+    </style>
+</head>
+<body>
+    <div id="container"></div>
+    <script>
+        window.renderKatex = async function(tex, displayMode, macrosJSON) {
+            const macros = JSON.parse(macrosJSON || '{}');
+            const container = document.getElementById('container');
+            container.innerHTML = '';
+            katex.render(tex, container, {
+                displayMode: displayMode === true || displayMode === 'true',
+                throwOnError: false,
+                macros
+            });
+            await new Promise(resolve => requestAnimationFrame(resolve));
+            const rect = container.getBoundingClientRect();
+            return {
+                width: Math.ceil(rect.width),
+                height: Math.ceil(rect.height)
+            };
+        }
+    </script>
+</body>
+</html>

--- a/Sources/MyTermNotesApp/AppState/Models/LatexCommandSet.swift
+++ b/Sources/MyTermNotesApp/AppState/Models/LatexCommandSet.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+struct LatexCommandSet: Codable, Equatable {
+    var macrosSource: String
+
+    var macros: [String: String] {
+        var dictionary: [String: String] = [:]
+        let lines = macrosSource.split(separator: "\n")
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            if let command = LatexCommandSet.parseMacro(from: trimmed) {
+                dictionary[command.key] = command.value
+            }
+        }
+        return dictionary
+    }
+
+    var environments: [LatexEnvironment] {
+        var definitions: [LatexEnvironment] = []
+        let lines = macrosSource.split(separator: "\n")
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            if let env = LatexCommandSet.parseEnvironment(from: trimmed) {
+                definitions.append(env)
+            }
+        }
+        return definitions
+    }
+
+    static func parseMacro(from line: String) -> (key: String, value: String)? {
+        let patterns = [
+            #"\\newcommand\{\\([a-zA-Z@]+)\}\{(.+)\}"#,
+            #"\\DeclareMathOperator\{\\([a-zA-Z@]+)\}\{(.+)\}"#
+        ]
+        for pattern in patterns {
+            if let regex = try? NSRegularExpression(pattern: pattern, options: []) {
+                let range = NSRange(line.startIndex..<line.endIndex, in: line)
+                if let match = regex.firstMatch(in: line, options: [], range: range), match.numberOfRanges >= 3,
+                   let keyRange = Range(match.range(at: 1), in: line),
+                   let valueRange = Range(match.range(at: 2), in: line) {
+                    let key = String(line[keyRange])
+                    let value = String(line[valueRange])
+                    return ("\\" + key, value)
+                }
+            }
+        }
+        return nil
+    }
+
+    static func parseEnvironment(from line: String) -> LatexEnvironment? {
+        let pattern = #"\\newenvironment\{([a-zA-Z*@]+)\}\{(.+)\}\{(.+)\}"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []),
+              let match = regex.firstMatch(in: line, options: [], range: NSRange(location: 0, length: line.utf16.count)),
+              match.numberOfRanges == 4,
+              let nameRange = Range(match.range(at: 1), in: line),
+              let beginRange = Range(match.range(at: 2), in: line),
+              let endRange = Range(match.range(at: 3), in: line) else {
+            return nil
+        }
+
+        return LatexEnvironment(
+            name: String(line[nameRange]),
+            beginBody: String(line[beginRange]),
+            endBody: String(line[endRange])
+        )
+    }
+
+    static let `default` = LatexCommandSet(
+        macrosSource: """
+\\newcommand{\\R}{\\mathbb{R}}
+\\newcommand{\\Q}{\\mathbb{Q}}
+\\newcommand{\\Z}{\\mathbb{Z}}
+\\newcommand{\\N}{\\mathbb{N}}
+\\DeclareMathOperator{\\im}{im}
+\\DeclareMathOperator{\\Hom}{Hom}
+\\newenvironment{lemma}{\\begin{aligned}}{\\end{aligned}}
+"""
+    )
+}
+
+struct LatexEnvironment: Codable, Equatable {
+    var name: String
+    var beginBody: String
+    var endBody: String
+}
+
+struct LatexRenderConfiguration: Equatable {
+    var macros: [String: String]
+    var environments: [LatexEnvironment]
+}

--- a/Sources/MyTermNotesApp/AppState/Models/Note.swift
+++ b/Sources/MyTermNotesApp/AppState/Models/Note.swift
@@ -1,0 +1,64 @@
+import Foundation
+import SwiftUI
+
+struct Note: Identifiable, Codable, Equatable {
+    var id: UUID
+    var title: String
+    var content: String
+    var createdAt: Date
+    var updatedAt: Date
+    var tint: NoteTint
+
+    init(id: UUID = UUID(), title: String = "", content: String = "", createdAt: Date = .init(), updatedAt: Date = .init(), tint: NoteTint = .vercelSand) {
+        self.id = id
+        self.title = title
+        self.content = content
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.tint = tint
+    }
+
+    var preview: String {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "Add your thoughts…" }
+        return String(trimmed.prefix(120))
+    }
+}
+
+struct NoteCollection: Codable {
+    var notes: [Note]
+    var selectedID: UUID?
+}
+
+enum NoteTint: String, CaseIterable, Codable, Identifiable {
+    case vercelSand
+    case vercelIris
+    case vercelMint
+    case vercelSun
+    case vercelOrange
+
+    var id: String { rawValue }
+
+    var color: Color {
+        switch self {
+        case .vercelSand:
+            return Color(red: 0.22, green: 0.22, blue: 0.24)
+        case .vercelIris:
+            return Color(red: 0.49, green: 0.42, blue: 0.93)
+        case .vercelMint:
+            return Color(red: 0.09, green: 0.74, blue: 0.63)
+        case .vercelSun:
+            return Color(red: 0.97, green: 0.73, blue: 0.29)
+        case .vercelOrange:
+            return Color(red: 0.99, green: 0.44, blue: 0.18)
+        }
+    }
+
+    var gradient: LinearGradient {
+        LinearGradient(
+            gradient: Gradient(colors: [color.opacity(0.95), color.opacity(0.65)]),
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+}

--- a/Sources/MyTermNotesApp/AppState/Store/LatexSettingsStore.swift
+++ b/Sources/MyTermNotesApp/AppState/Store/LatexSettingsStore.swift
@@ -1,0 +1,45 @@
+import Combine
+import Foundation
+
+@MainActor
+final class LatexSettingsStore: ObservableObject {
+    @Published var commandSet: LatexCommandSet
+
+    private let storageURL: URL
+
+    init(fileManager: FileManager = .default) {
+        let support = try? fileManager.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        storageURL = support?.appending(path: "MyTermNotes/latex.json") ?? URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: "MyTermNotes/latex.json")
+        if let data = try? Data(contentsOf: storageURL),
+           let decoded = try? JSONDecoder().decode(LatexCommandSet.self, from: data) {
+            commandSet = decoded
+        } else {
+            commandSet = .default
+        }
+
+        $commandSet
+            .dropFirst()
+            .debounce(for: .seconds(0.6), scheduler: RunLoop.main)
+            .sink { [weak self] commandSet in
+                Task { await self?.persist(commandSet) }
+            }
+            .store(in: &cancellables)
+    }
+
+    var configuration: LatexRenderConfiguration {
+        LatexRenderConfiguration(macros: commandSet.macros, environments: commandSet.environments)
+    }
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    private func persist(_ commandSet: LatexCommandSet) async {
+        do {
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(commandSet)
+            try FileManager.default.createDirectory(at: storageURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try data.write(to: storageURL, options: .atomic)
+        } catch {
+            NSLog("Failed to persist LaTeX command set: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/MyTermNotesApp/AppState/Store/NotesStore.swift
+++ b/Sources/MyTermNotesApp/AppState/Store/NotesStore.swift
@@ -1,0 +1,124 @@
+import Combine
+import Foundation
+
+@MainActor
+final class NotesStore: ObservableObject {
+    @Published private(set) var notes: [Note] = []
+    @Published var selectedNoteID: Note.ID?
+
+    private let storageURL: URL
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(fileManager: FileManager = .default) {
+        let support = try? fileManager.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        storageURL = support?.appending(path: "MyTermNotes/notes.json") ?? URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: "MyTermNotes/notes.json")
+
+        Task {
+            await load()
+        }
+
+        $notes
+            .dropFirst()
+            .debounce(for: .seconds(0.5), scheduler: RunLoop.main)
+            .sink { [weak self] notes in
+                Task { await self?.persist(notes: notes) }
+            }
+            .store(in: &cancellables)
+
+        $selectedNoteID
+            .dropFirst()
+            .debounce(for: .seconds(0.5), scheduler: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                Task { await self.persist(notes: self.notes) }
+            }
+            .store(in: &cancellables)
+    }
+
+    func createNote() {
+        var note = Note()
+        note.title = "New Note"
+        note.content = ""
+        note.tint = NoteTint.allCases.randomElement() ?? .vercelSand
+        note.createdAt = Date()
+        note.updatedAt = Date()
+        notes.insert(note, at: 0)
+        selectedNoteID = note.id
+        reorderNotes()
+    }
+
+    func delete(_ note: Note) {
+        notes.removeAll { $0.id == note.id }
+        if selectedNoteID == note.id {
+            selectedNoteID = notes.first?.id
+        }
+    }
+
+    func update(note: Note, title: String, content: String) {
+        guard let index = notes.firstIndex(where: { $0.id == note.id }) else { return }
+        notes[index].title = title
+        notes[index].content = content
+        notes[index].updatedAt = Date()
+        selectedNoteID = note.id
+        reorderNotes()
+    }
+
+    func updateTint(for note: Note, tint: NoteTint) {
+        guard let index = notes.firstIndex(where: { $0.id == note.id }) else { return }
+        notes[index].tint = tint
+        notes[index].updatedAt = Date()
+        selectedNoteID = note.id
+        reorderNotes()
+    }
+
+    func select(_ note: Note?) {
+        selectedNoteID = note?.id
+    }
+
+    private func load() async {
+        do {
+            let data = try Data(contentsOf: storageURL)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let collection = try decoder.decode(NoteCollection.self, from: data)
+            notes = collection.notes
+            selectedNoteID = collection.selectedID ?? collection.notes.first?.id
+        } catch {
+            notes = []
+            selectedNoteID = nil
+        }
+
+        if notes.isEmpty {
+            createNote()
+        }
+
+        reorderNotes()
+    }
+
+    private func persist(notes: [Note]) async {
+        let collection = NoteCollection(notes: notes, selectedID: selectedNoteID)
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = .prettyPrinted
+            let data = try encoder.encode(collection)
+            try FileManager.default.createDirectory(at: storageURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try data.write(to: storageURL, options: .atomic)
+        } catch {
+            NSLog("Failed to persist notes: \(error.localizedDescription)")
+        }
+    }
+
+    private func reorderNotes() {
+        notes.sort { lhs, rhs in
+            if lhs.updatedAt == rhs.updatedAt {
+                return lhs.createdAt > rhs.createdAt
+            }
+            return lhs.updatedAt > rhs.updatedAt
+        }
+        if let selectedNoteID,
+           let selectedIndex = notes.firstIndex(where: { $0.id == selectedNoteID }) {
+            selectedNoteID = notes[selectedIndex].id
+        }
+    }
+}

--- a/Sources/MyTermNotesApp/Latex/LatexAttachment.swift
+++ b/Sources/MyTermNotesApp/Latex/LatexAttachment.swift
@@ -1,0 +1,38 @@
+import AppKit
+
+final class LatexAttachmentCell: NSTextAttachmentCell {
+    private let image: NSImage
+
+    init(image: NSImage) {
+        self.image = image
+        super.init(imageCell: image)
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func cellSize() -> NSSize {
+        var size = image.size
+        size.width += 8
+        size.height += 8
+        return size
+    }
+
+    override func draw(withFrame cellFrame: NSRect, in controlView: NSView?) {
+        let rect = cellFrame.insetBy(dx: 4, dy: 4)
+        NSColor.windowBackgroundColor.setFill()
+        let background = NSBezierPath(roundedRect: rect, xRadius: 8, yRadius: 8)
+        background.fill()
+
+        image.draw(in: rect)
+    }
+}
+
+final class LatexAttachmentBuilder {
+    static func makeAttachment(from image: NSImage) -> NSTextAttachment {
+        let attachment = NSTextAttachment()
+        attachment.attachmentCell = LatexAttachmentCell(image: image)
+        return attachment
+    }
+}

--- a/Sources/MyTermNotesApp/Latex/LatexParser.swift
+++ b/Sources/MyTermNotesApp/Latex/LatexParser.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+struct LatexSegment: Identifiable, Hashable {
+    let id = UUID()
+    let range: NSRange
+    let latex: String
+    let displayMode: Bool
+}
+
+enum LatexParser {
+    static func segments(in text: String) -> [LatexSegment] {
+        var segments: [LatexSegment] = []
+        let nsText = text as NSString
+
+        // Block $$...$$ and \[ ... \]
+        let blockPatterns = [
+            #"\$\$(.+?)\$\$"#,
+            #"\\\[(.+?)\\\]"#
+        ]
+        for pattern in blockPatterns {
+            if let blockRegex = try? NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators]) {
+            let matches = blockRegex.matches(in: text, options: [], range: NSRange(location: 0, length: nsText.length))
+            for match in matches {
+                guard match.numberOfRanges >= 2 else { continue }
+                let latexRange = match.range(at: 1)
+                let displayRange = match.range(at: 0)
+                let latex = nsText.substring(with: latexRange)
+                segments.append(LatexSegment(range: displayRange, latex: latex, displayMode: true))
+            }
+        }
+        }
+
+        // Environments \begin{...} ... \end{...}
+        if let envRegex = try? NSRegularExpression(pattern: #"\\begin\{([a-zA-Z*]+)\}([\\s\\S]*?)\\end\{\1\}"#, options: []) {
+            let matches = envRegex.matches(in: text, options: [], range: NSRange(location: 0, length: nsText.length))
+            for match in matches {
+                guard match.numberOfRanges >= 3 else { continue }
+                let contentRange = match.range(at: 0)
+                let latex = nsText.substring(with: contentRange)
+                segments.append(LatexSegment(range: contentRange, latex: latex, displayMode: true))
+            }
+        }
+
+        // Inline $...$ and \(...\)
+        let inlinePatterns = [
+            #"(?<!\\)\$(.+?)(?<!\\)\$"#,
+            #"\\\((.+?)\\\)"#
+        ]
+        for pattern in inlinePatterns {
+            if let inlineRegex = try? NSRegularExpression(pattern: pattern, options: []) {
+                let matches = inlineRegex.matches(in: text, options: [], range: NSRange(location: 0, length: nsText.length))
+                for match in matches {
+                    guard match.numberOfRanges >= 2 else { continue }
+                    let latexRange = match.range(at: 1)
+                    let displayRange = match.range(at: 0)
+                    let latex = nsText.substring(with: latexRange)
+                    segments.append(LatexSegment(range: displayRange, latex: latex, displayMode: latex.contains("\\n")))
+                }
+            }
+        }
+
+        // Deduplicate overlapping ranges, prioritizing larger blocks
+        let sorted = segments.sorted { lhs, rhs in
+            if lhs.range.location == rhs.range.location {
+                return lhs.range.length > rhs.range.length
+            }
+            return lhs.range.location < rhs.range.location
+        }
+
+        var deduped: [LatexSegment] = []
+        for segment in sorted {
+            if deduped.contains(where: { NSIntersectionRange($0.range, segment.range).length > 0 }) {
+                continue
+            }
+            deduped.append(segment)
+        }
+
+        return deduped.sorted { $0.range.location < $1.range.location }
+    }
+}

--- a/Sources/MyTermNotesApp/Latex/LatexRenderer.swift
+++ b/Sources/MyTermNotesApp/Latex/LatexRenderer.swift
@@ -1,0 +1,115 @@
+import AppKit
+import WebKit
+
+@MainActor
+final class LatexRenderer: NSObject {
+    static let shared = LatexRenderer()
+
+    private let webView: WKWebView
+    private var isLoaded = false
+
+    override init() {
+        let config = WKWebViewConfiguration()
+        config.preferences.javaScriptEnabled = true
+        config.limitsNavigationsToAppBoundDomains = true
+        config.defaultWebpagePreferences.allowsContentJavaScript = true
+        webView = WKWebView(frame: .zero, configuration: config)
+        webView.isHidden = true
+        webView.setValue(false, forKey: "drawsBackground")
+        webView.isOpaque = false
+        webView.navigationDelegate = self
+        super.init()
+        loadRenderer()
+    }
+
+    private func loadRenderer() {
+        guard !isLoaded else { return }
+        if let url = Bundle.module.url(forResource: "renderer", withExtension: "html", subdirectory: "Renderer") {
+            isLoaded = false
+            webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+        }
+    }
+
+    func render(_ latex: String, displayMode: Bool, configuration: LatexRenderConfiguration) async throws -> NSImage {
+        try await waitUntilLoaded()
+        let escapedLatex = latex
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "`", with: "\\`")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "")
+        let macrosJSON = try encodeMacros(configuration: configuration)
+        let script = "renderKatex(\"\(escapedLatex)\", \(displayMode ? "true" : "false"), \(macrosJSON))"
+        guard let sizeDict = try await webView.callAsyncJavaScript(script) as? [String: Any] else {
+            throw LatexRendererError.failedToDecode
+        }
+
+        func extract(_ key: String) -> Double? {
+            if let value = sizeDict[key] as? Double { return value }
+            if let number = sizeDict[key] as? NSNumber { return number.doubleValue }
+            return nil
+        }
+
+        guard let width = extract("width"), let height = extract("height") else {
+            throw LatexRendererError.failedToDecode
+        }
+
+        let size = CGSize(width: max(width + 24, 1), height: max(height + 24, 1))
+        await MainActor.run {
+            webView.setFrameSize(size)
+            webView.layoutSubtreeIfNeeded()
+        }
+
+        let configuration = WKSnapshotConfiguration()
+        configuration.rect = CGRect(origin: .zero, size: size)
+        configuration.afterScreenUpdates = true
+        guard let image = try await webView.takeSnapshot(with: configuration) else {
+            throw LatexRendererError.failedToDecode
+        }
+        return image
+    }
+
+    private func encodeMacros(configuration: LatexRenderConfiguration) throws -> String {
+        var macros = configuration.macros
+        for environment in configuration.environments {
+            macros["\\begin{\(environment.name)}"] = environment.beginBody
+            macros["\\end{\(environment.name)}"] = environment.endBody
+        }
+
+        guard let data = try? JSONSerialization.data(withJSONObject: macros, options: []) else {
+            throw LatexRendererError.failedToEncodeMacros
+        }
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw LatexRendererError.failedToEncodeMacros
+        }
+        return string
+    }
+
+    private func waitUntilLoaded() async throws {
+        var attempt = 0
+        while !isLoaded {
+            try await Task.sleep(nanoseconds: 50_000_000)
+            attempt += 1
+            if attempt > 20 {
+                throw LatexRendererError.rendererNotLoaded
+            }
+        }
+    }
+}
+
+enum LatexRendererError: Error {
+    case rendererNotLoaded
+    case failedToEncodeMacros
+    case failedToDecode
+}
+
+extension LatexRenderer: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        isLoaded = true
+    }
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        isLoaded = false
+        loadRenderer()
+    }
+}

--- a/Sources/MyTermNotesApp/MyTermNotesApp.swift
+++ b/Sources/MyTermNotesApp/MyTermNotesApp.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+@main
+struct MyTermNotesApp: App {
+    @StateObject private var notesStore = NotesStore()
+    @StateObject private var settingsStore = LatexSettingsStore()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(notesStore)
+                .environmentObject(settingsStore)
+                .frame(minWidth: 960, minHeight: 600)
+        }
+        .commands {
+            CommandGroup(replacing: .newItem) {
+                Button(action: notesStore.createNote) {
+                    Text("New Note")
+                }
+                .keyboardShortcut("n", modifiers: [.command])
+            }
+        }
+
+        Settings {
+            LatexSettingsView()
+                .environmentObject(settingsStore)
+                .padding(24)
+                .frame(width: 520, height: 520)
+        }
+    }
+}

--- a/Sources/MyTermNotesApp/Views/Components/LatexTextViewRepresentable.swift
+++ b/Sources/MyTermNotesApp/Views/Components/LatexTextViewRepresentable.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import AppKit
+
+struct LatexTextViewRepresentable: NSViewRepresentable {
+    @Binding var text: String
+    var configuration: LatexRenderConfiguration
+    var onUpdate: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text, configuration: configuration, onUpdate: onUpdate)
+    }
+
+    func makeNSView(context: Context) -> NSTextView {
+        let textView = NSTextView()
+        textView.delegate = context.coordinator
+        textView.isRichText = true
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDataDetectionEnabled = false
+        textView.font = .systemFont(ofSize: 16, weight: .regular)
+        textView.textContainerInset = NSSize(width: 20, height: 20)
+        textView.backgroundColor = NSColor.controlBackgroundColor
+        textView.string = text
+        textView.allowsUndo = true
+        textView.usesAdaptiveColorMappingForDarkAppearance = true
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(width: textView.bounds.width, height: CGFloat.greatestFiniteMagnitude)
+        context.coordinator.renderLatex(in: textView)
+        return textView
+    }
+
+    func updateNSView(_ nsView: NSTextView, context: Context) {
+        context.coordinator.configuration = configuration
+        if nsView.string != text {
+            nsView.string = text
+            context.coordinator.renderLatex(in: nsView)
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        @Binding var text: String
+        var configuration: LatexRenderConfiguration
+        var onUpdate: (String) -> Void
+        private var isApplyingAttributedString = false
+
+        init(text: Binding<String>, configuration: LatexRenderConfiguration, onUpdate: @escaping (String) -> Void) {
+            _text = text
+            self.configuration = configuration
+            self.onUpdate = onUpdate
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            guard !isApplyingAttributedString else { return }
+            text = textView.string
+            onUpdate(textView.string)
+            renderLatex(in: textView)
+        }
+
+        func renderLatex(in textView: NSTextView) {
+            let currentSelected = textView.selectedRange()
+            let baseAttributes: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 16, weight: .regular),
+                .foregroundColor: NSColor.labelColor
+            ]
+            let attributed = NSMutableAttributedString(string: textView.string, attributes: baseAttributes)
+            let segments = LatexParser.segments(in: textView.string)
+            let renderConfiguration = configuration
+
+            if segments.isEmpty {
+                isApplyingAttributedString = true
+                textView.textStorage?.setAttributedString(attributed)
+                textView.setSelectedRange(currentSelected)
+                isApplyingAttributedString = false
+                return
+            }
+
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                for segment in segments.reversed() {
+                    do {
+                        let image = try await LatexRenderer.shared.render(segment.latex, displayMode: segment.displayMode, configuration: renderConfiguration)
+                        let attachment = LatexAttachmentBuilder.makeAttachment(from: image)
+                        let replacement = NSAttributedString(attachment: attachment)
+                        attributed.replaceCharacters(in: segment.range, with: replacement)
+                    } catch {
+                        continue
+                    }
+                }
+
+                self.isApplyingAttributedString = true
+                textView.textStorage?.setAttributedString(attributed)
+                textView.setSelectedRange(currentSelected)
+                self.isApplyingAttributedString = false
+            }
+        }
+    }
+}

--- a/Sources/MyTermNotesApp/Views/Components/NoteEditorContainer.swift
+++ b/Sources/MyTermNotesApp/Views/Components/NoteEditorContainer.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+struct NoteEditorContainer: View {
+    @EnvironmentObject private var notesStore: NotesStore
+    @EnvironmentObject private var settingsStore: LatexSettingsStore
+
+    @State private var title: String
+    @State private var content: String
+    private let noteID: Note.ID
+
+    init(note: Note) {
+        self.noteID = note.id
+        _title = State(initialValue: note.title)
+        _content = State(initialValue: note.content)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let note = currentNote {
+                HStack(spacing: 16) {
+                TextField("Title", text: $title)
+                    .font(.system(size: 30, weight: .bold, design: .rounded))
+                    .textFieldStyle(.plain)
+                    .foregroundColor(Theme.primaryText)
+                    .onChange(of: title) { _ in updateNote() }
+
+                Spacer()
+
+                Menu {
+                    ForEach(NoteTint.allCases) { tint in
+                        Button(action: { notesStore.updateTint(for: note, tint: tint) }) {
+                            Label(tint.id.capitalized, systemImage: note.tint == tint ? "checkmark" : "")
+                        }
+                    }
+                } label: {
+                    Capsule()
+                        .fill(note.tint.gradient)
+                        .frame(width: 60, height: 24)
+                        .overlay(
+                            Capsule()
+                                .strokeBorder(Color.white.opacity(0.4), lineWidth: 0.8)
+                        )
+                        .shadow(color: note.tint.color.opacity(0.3), radius: 10, y: 4)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                }
+                .padding(.horizontal, 32)
+                .padding(.top, 28)
+                .padding(.bottom, 16)
+
+                Divider()
+                    .background(Theme.separator)
+
+                LatexTextViewRepresentable(text: $content, configuration: settingsStore.configuration) { newValue in
+                    notesStore.update(note: note, title: title, content: newValue)
+                }
+                .background(Theme.editorBackground)
+            } else {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .background(Theme.editorBackground.ignoresSafeArea())
+        .onChange(of: notesStore.notes) { _ in
+            if let note = currentNote {
+                if title != note.title {
+                    title = note.title
+                }
+                if content != note.content {
+                    content = note.content
+                }
+            }
+        }
+    }
+
+    private func updateNote() {
+        guard let note = currentNote else { return }
+        notesStore.update(note: note, title: title, content: content)
+    }
+
+    private var currentNote: Note? {
+        notesStore.notes.first { $0.id == noteID }
+    }
+}

--- a/Sources/MyTermNotesApp/Views/Components/NoteListItemView.swift
+++ b/Sources/MyTermNotesApp/Views/Components/NoteListItemView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct NoteListItemView: View {
+    let note: Note
+    let isSelected: Bool
+
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: note.updatedAt)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(note.title.isEmpty ? "Untitled" : note.title)
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundColor(isSelected ? .white : Color.primary.opacity(0.92))
+                    .lineLimit(1)
+
+                Spacer()
+
+                Circle()
+                    .fill(note.tint.gradient)
+                    .frame(width: 8, height: 8)
+            }
+
+            Text(formattedDate)
+                .font(.system(size: 12, weight: .medium, design: .rounded))
+                .foregroundStyle(isSelected ? Color.white.opacity(0.7) : Color.secondary)
+
+            Text(note.preview)
+                .font(.system(size: 13, weight: .regular, design: .rounded))
+                .foregroundColor(isSelected ? Color.white.opacity(0.85) : Color.secondary)
+                .lineLimit(2)
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(isSelected ? note.tint.gradient : Color(.windowBackgroundColor))
+                .shadow(color: isSelected ? note.tint.color.opacity(0.35) : Color.black.opacity(0.06), radius: isSelected ? 16 : 6, y: isSelected ? 8 : 2)
+        )
+        .padding(.horizontal, 6)
+        .padding(.vertical, 4)
+    }
+}

--- a/Sources/MyTermNotesApp/Views/Components/SidebarView.swift
+++ b/Sources/MyTermNotesApp/Views/Components/SidebarView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct SidebarView: View {
+    @EnvironmentObject private var notesStore: NotesStore
+    @State private var searchText = ""
+    @Binding var selectedNote: Note?
+
+    private var filteredNotes: [Note] {
+        guard !searchText.isEmpty else { return notesStore.notes }
+        return notesStore.notes.filter { note in
+            note.title.localizedCaseInsensitiveContains(searchText) ||
+            note.content.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(spacing: 12) {
+                HStack {
+                    Text("Notes")
+                        .font(.system(size: 28, weight: .bold, design: .rounded))
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    Button(action: notesStore.createNote) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 16, weight: .bold))
+                            .foregroundStyle(.white)
+                            .frame(width: 28, height: 28)
+                            .background(Theme.accentGradient)
+                            .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+                            .shadow(color: Theme.accent.opacity(0.4), radius: 12, y: 6)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Create a new note")
+                }
+
+                TextField("Search", text: $searchText)
+                    .textFieldStyle(.roundedBorder)
+                    .cornerRadius(12)
+                    .padding(.top, 4)
+            }
+            .padding(20)
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(filteredNotes) { note in
+                        NoteListItemView(note: note, isSelected: selectedNote?.id == note.id)
+                            .contentShape(Rectangle())
+                            .onTapGesture { selectedNote = note }
+                            .contextMenu {
+                                Button("Delete", role: .destructive) {
+                                    notesStore.delete(note)
+                                }
+                                Divider()
+                                Menu("Tint") {
+                                    ForEach(NoteTint.allCases) { tint in
+                                        Button(action: { applyTint(tint, to: note) }) {
+                                            Label(tint.id.capitalized, systemImage: note.tint == tint ? "checkmark" : "")
+                                        }
+                                    }
+                                }
+                            }
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+        }
+        .background(Theme.sidebarBackground)
+    }
+
+    private func applyTint(_ tint: NoteTint, to note: Note) {
+        notesStore.updateTint(for: note, tint: tint)
+    }
+}

--- a/Sources/MyTermNotesApp/Views/Components/Theme.swift
+++ b/Sources/MyTermNotesApp/Views/Components/Theme.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+enum Theme {
+    static let accent = Color(red: 0.11, green: 0.11, blue: 0.12)
+    static let sidebarBackground = Color(nsColor: NSColor.windowBackgroundColor).opacity(0.92)
+    static let editorBackground = Color(nsColor: NSColor.controlBackgroundColor)
+    static let primaryText = Color.primary
+    static let separator = Color.black.opacity(0.05)
+
+    static let accentGradient = LinearGradient(
+        colors: [accent.opacity(0.92), accent.opacity(0.7)],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+}

--- a/Sources/MyTermNotesApp/Views/ContentView.swift
+++ b/Sources/MyTermNotesApp/Views/ContentView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var notesStore: NotesStore
+    @EnvironmentObject private var settingsStore: LatexSettingsStore
+
+    var body: some View {
+        NavigationSplitView {
+            SidebarView(selectedNote: Binding(
+                get: { selectedNote },
+                set: { notesStore.select($0) }
+            ))
+            .navigationSplitViewColumnWidth(min: 240, ideal: 260)
+            .background(Theme.sidebarBackground)
+        } detail: {
+            if let selectedNote {
+                NoteEditorContainer(note: selectedNote)
+                    .environmentObject(settingsStore)
+                    .environmentObject(notesStore)
+                    .background(Theme.editorBackground)
+            } else {
+                PlaceholderView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Theme.editorBackground)
+            }
+        }
+        .tint(Theme.accent)
+    }
+
+    private var selectedNote: Note? {
+        guard let id = notesStore.selectedNoteID else { return nil }
+        return notesStore.notes.first { $0.id == id }
+    }
+}
+
+struct PlaceholderView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "square.and.pencil")
+                .font(.system(size: 52, weight: .medium))
+                .foregroundStyle(.ultraThinMaterial)
+            Text("Choose or create a note")
+                .font(.system(size: 22, weight: .semibold, design: .rounded))
+                .foregroundColor(.secondary)
+        }
+    }
+}

--- a/Sources/MyTermNotesApp/Views/Settings/LatexSettingsView.swift
+++ b/Sources/MyTermNotesApp/Views/Settings/LatexSettingsView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct LatexSettingsView: View {
+    @EnvironmentObject private var settingsStore: LatexSettingsStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("LaTeX Commands")
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                Text("Paste your custom \newcommand, \DeclareMathOperator, and \newenvironment definitions. These macros will be available across every note.")
+                    .font(.system(size: 14, weight: .medium, design: .rounded))
+                    .foregroundColor(.secondary)
+            }
+
+            TextEditor(text: Binding(
+                get: { settingsStore.commandSet.macrosSource },
+                set: { newValue in settingsStore.commandSet.macrosSource = newValue }
+            ))
+            .font(.system(size: 14, weight: .regular, design: .monospaced))
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(Color(nsColor: NSColor.controlBackgroundColor))
+                    .shadow(color: Color.black.opacity(0.08), radius: 12, y: 6)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(Color.black.opacity(0.05), lineWidth: 1)
+            )
+
+            Spacer()
+
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Tips")
+                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                Label("Inline math: $f(x) = x^2$", systemImage: "function")
+                Label("Display math: $$\\begin{align*} a & = b \\ c & = d \end{align*}$$", systemImage: "text.alignleft")
+                Label("Environment blocks: \\begin{lemma} ... \\end{lemma}", systemImage: "square.grid.2x2")
+                Label("Operators: \\DeclareMathOperator{\\Spec}{Spec}", systemImage: "sum")
+            }
+            .font(.system(size: 13, weight: .medium, design: .rounded))
+            .foregroundColor(.secondary)
+        }
+        .padding(24)
+    }
+}


### PR DESCRIPTION
## Summary
- create a SwiftUI macOS notes experience with a Vercel-inspired sidebar, editor, and settings window
- add inline/block LaTeX parsing plus a WebKit-powered KaTeX renderer that swaps math regions with rich attachments while you type
- persist notes and LaTeX macro/environment definitions, exposing custom commands in the Settings screen

## Testing
- not run (macOS app target requires Xcode/macOS environment)


------
https://chatgpt.com/codex/tasks/task_b_68e014d619cc8324886e6505e4c4b4f6